### PR TITLE
Add support for source maps.

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ Available options to pass as second argument:
 | `mediaMap`           | `{}`        | This allows you to define media query shortcuts which are expanded on building the CSS. Example: using `{ phone: "media only screen and (max-width: 640px)" }` as value for this option and a stylesheet spec having `"@phone"` as a key, that key will be translated to `@media only screen and (max-width: 640px)` in the final CSS. |
 | `context`            | `null`      | If set to an object, each identifier found on the right-hand side of a style rule is substituted with the corresponding property value of this object.
 | `cacheDir`           | `null`      | If set to a string value, e.g. `"tmp/cache/"`, the class name cache will be persisted in a file in this directory. Otherwise, an in-memory cache is used.                                                                                                                                                                                 |
+| `sourceMapName`           | `null`      | If set to a string value, a source map will be generated with the given name and returned as `map`, e.g. `result.map` in the example above.                                                                                                                                                                                 |
 
 #### `object Extractor.transformFile(string filename, [object options], function callback)`
 

--- a/src/Extractor.js
+++ b/src/Extractor.js
@@ -12,14 +12,23 @@ export function transform(source, options = {}) {
   options.filename = options.filename || 'unknown';
 
   let stylesheets = {};
-  let ast = parse(source);
+  let ast = parse(source, {
+    sourceFileName: options.filename
+  });
 
   transformAST(ast, stylesheets, options);
 
-  const code = print(ast).code;
+  let printOptions = {};
+
+  if (options.sourceMapName) {
+    printOptions.sourceMapName = options.sourceMapName;
+  }
+
+  const result = print(ast, printOptions);
+  const { code, map } = result;
   const css = buildCSS(stylesheets, options);
 
-  return { code, css };
+  return { code, map, css };
 }
 
 export function transformFile(filename, options, callback) {

--- a/test/spec.js
+++ b/test/spec.js
@@ -136,6 +136,15 @@ describe('Extractor.transform', () => {
     assert(css.indexOf('.unknown-styles-foo') > -1);
   });
 
+  it('returns a source map if sourceMapName is provided', () => {
+    const { map } = Extractor.transform('', {
+      filename: 'test.js',
+      sourceMapName: 'test.map'
+    });
+
+    assert.strictEqual(map.file, 'test.map');
+  });
+
   it('works with StyleSheet["create"](...)', () => {
     const css = testTransformed({
       from: 'var styles = StyleSheet["create"]({ foo: { content: "x" } });',


### PR DESCRIPTION
If `sourceMapName` is specified, return the source map generated by recast in Extractor.transform().