### PR TITLE
Upgrade autoprefixer-core

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "rix": "./bin/cli.js"
   },
   "dependencies": {
-    "autoprefixer-core": "^5.1.9",
+    "autoprefixer-core": "^5.2.0",
     "babel-core": "^5.2.15",
     "babel-runtime": "^5.2.15",
     "clean-css": "^3.2.8",
@@ -41,6 +41,7 @@
     "glob": "^5.0.3",
     "mkdirp": "^0.5.0",
     "object-assign": "^2.0.0",
+    "postcss": "^4.1.11",
     "recast": "^0.10.12"
   },
   "devDependencies": {

--- a/src/buildCSS.js
+++ b/src/buildCSS.js
@@ -1,3 +1,4 @@
+import postcss from 'postcss';
 import autoprefixer from 'autoprefixer-core';
 import CleanCSS from 'clean-css';
 import foreach from 'foreach';
@@ -25,9 +26,9 @@ export default function(stylesheets, options) {
 
   if (vp) {
     if (typeof vp === 'object') {
-      css = autoprefixer(vp).process(css).css;
+      css = postcss([autoprefixer(vp)]).process(css).css;
     } else {
-      css = autoprefixer.process(css).css;
+      css = postcss([autoprefixer]).process(css).css;
     }
   }
 


### PR DESCRIPTION
This removes the warning message generated with auto prefixes:
```
Autoprefixer's process() method is deprecated and will removed in next
major release. Use postcss([autoprefixer]).process() instead
```

This change bumps `autoprefixer-core` to the latest stable version, adds
`postcss` as a new dependency, and makes the necessary API change in
buildCSS().