### PR TITLE
Add missing  'export default' to StyleSheet.js

### DIFF
--- a/src/StyleSheet.js
+++ b/src/StyleSheet.js
@@ -2,4 +2,4 @@ function create(spec) {
   return spec;
 }
 
-export { create };
+export default { create };


### PR DESCRIPTION
Since StyleSheet.js can't be loaded in nodejs environment using require('babel-core/register') So I've added `export default` to StyleSheet.js.

I've been associated with some projects which use react-inline and webpack. Before embarking on the task, I always needed to type 'webpack --watch' and 'rix --watch src dest' in order to run two processes at the same time. It was so uncomfortable that I wanted to combine two tasks using webpack loader. I'm developing react-inline-extractor-webpack-loader, rix-loader.

I was thinking that the rix-loader could not only extract CSS well but also have one additional feature regarding context option. I wanted to give react-inline-extrator a context option when the rix-loader is run. So, I've inserted the code, `export { rixContext }`, in React Component sources. I have in mind to let rix-loader access this `rixContext object`. In this process, as React Components are written mostly using ES6, it is required to use require('babel-core/resister') in order to load module.

Actually loading React Components at react compile time is very expensive because it also load all dependent modules like a react, react-addons, super classs, sub components, app utils, (in flux) actions, stores, and so on...  by nodejs. But I decided to make rix-loader. It allow developer to use any logic in CSS so that this can be substitute css preprocess like a less, sass, stylus. Sure, It is needed many test, experimentation, and many time.

Finally, it is my first gihub pull request. If you have any questions or sense delay, please let me collaborate with you. Thanks.

rix-loader github: 
- https://github.com/b6pzeusbc54tvhw5jgpyw8pwz2x6gs/rix-loader
